### PR TITLE
Handle mass claim prevention and already claimed

### DIFF
--- a/blossom_wrapper/__init__.py
+++ b/blossom_wrapper/__init__.py
@@ -248,7 +248,7 @@ class BlossomAPI:
         elif response.status_code == 404:
             return BlossomResponse(status=BlossomStatus.not_found)
         elif response.status_code == 409:
-            return BlossomResponse(status=BlossomStatus.already_claimed)
+            return BlossomResponse(data=response.json(), status=BlossomStatus.already_claimed)
         elif response.status_code == 423:
             return BlossomResponse(status=BlossomStatus.blacklisted)
         response.raise_for_status()

--- a/blossom_wrapper/__init__.py
+++ b/blossom_wrapper/__init__.py
@@ -10,6 +10,7 @@ from urllib3.util.retry import Retry  # type: ignore
 
 class BlossomStatus(Enum):
     already_claimed = auto()
+    too_many_claims = auto()
     already_completed = auto()
     blacklisted = auto()
     coc_not_accepted = auto()
@@ -251,6 +252,8 @@ class BlossomAPI:
             return BlossomResponse(data=response.json(), status=BlossomStatus.already_claimed)
         elif response.status_code == 423:
             return BlossomResponse(status=BlossomStatus.blacklisted)
+        elif response.status_code == 460:
+            return BlossomResponse(data=response.json(), status=BlossomStatus.too_many_claims)
         response.raise_for_status()
         return BlossomResponse()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "blossom-wrapper"
-version = "0.3.0"
+version = "0.4.0"
 description = ""
 authors = ["Grafeas Group Ltd. <devs@grafeas.org>"]
 license = "MIT"

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="blossom-wrapper",
-    version="0.3.0",
+    version="0.4.0",
     author="Grafeas Group",
     author_email="info@grafeas.org",
     description="Wrapper for the Blossom API",


### PR DESCRIPTION
Relevant issue: GrafeasGroup/blossom#183, GrafeasGroup/blossom#185

## Description:

This handles the API changes that will be introduced soon in Blossom. When claiming, a `409 already claimed` response now returns the user who claimed the submission in the data (GrafeasGroup/blossom#185). Also a new `460 too many claim` response will be added (GrafeasGroup/blossom#183).

This needs to be merged before we can handle these changes in GrafeasGroup/tor.

## Checklist:

- [X] Code Quality
- [ ] Pep-8
- [ ] Tests (if applicable)
- [X] Success Criteria Met
- [ ] Inline Documentation
- [ ] Wiki Documentation (if applicable)
